### PR TITLE
Option link fix in preload js

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -7,7 +7,7 @@ exports.onRenderBody = ({
 }) => {
   setPreBodyComponents([<div id="preloader"></div>])
   setHeadComponents([
-    <link as="script" rel="prerender" href="/scripts/preloader.js" />,
+    <link as="script" rel="preload" href="/scripts/preloader.js" />,
   ])
   setPostBodyComponents([<script src="/scripts/preloader.js" />])
 }


### PR DESCRIPTION
<!-- merge_request.md -->

## Type

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature

## What this change does:
- Fix rel option to preload instead

## Caveats, Assumptions and Shortcomings
- N/A

## Risk, Regression, Worst Case scenario
- N/A

## Testing Performed
- N/A

### Comments
- N/A